### PR TITLE
use register_transformer

### DIFF
--- a/lib/react-jsx-sprockets.rb
+++ b/lib/react-jsx-sprockets.rb
@@ -16,6 +16,13 @@ module ReactJSXSprockets
   # Register extention(s) with Sprockets
   require 'sprockets'
   ReactJSXSprockets.template_extensions.each do |ext|
-    Sprockets.register_engine ".#{ext}", Tilt
+    if Sprockets.respond_to?(:register_engine)
+      args = [".#{ext}", Tilt]
+      args << { mime_type: "application/#{ext}", silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+      Sprockets.register_engine(*args)
+    end
+
+    Sprockets.register_mime_type "application/#{ext}",  extensions: [".js.#{ext}",".#{ext}"], charset: :unicode
+    Sprockets.register_transformer "application/#{ext}", Tilt.default_mime_type, Tilt
   end
 end


### PR DESCRIPTION
fixes Sprockets method `register_engine` is  deprecated.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
