### PR TITLE
Updated tilt to also support proc interface.

### DIFF
--- a/lib/react-jsx-sprockets/tilt.rb
+++ b/lib/react-jsx-sprockets/tilt.rb
@@ -7,15 +7,20 @@ module ReactJSXSprockets
     CompileError = Class.new(StandardError)
 
     def evaluate(scope, locals, &block)
+      self.call(data:data)
+    end
+
+    def prepare; end
+
+    # new sprockets expects a proc rather than tilt
+    def self.call(input)
       begin
-        output = JSX.compile(data)
+        output = JSX.compile(input[:data])
       rescue ExecJS::RuntimeError => e
         raise CompileError.new("ReactJSXSprockets: Failed to compile: #{e.inspect}")
       end
 
       output
     end
-
-    def prepare; end
   end
 end

--- a/lib/react-jsx-sprockets/version.rb
+++ b/lib/react-jsx-sprockets/version.rb
@@ -1,3 +1,3 @@
 module ReactJSXSprockets
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end


### PR DESCRIPTION
As of the latest version of sprockets tilt is deprecated.
http://edgeguides.rubyonrails.org/asset_pipeline.html#making-your-library-or-gem-a-pre-processor

This change updates the Tilt object to also support call so it will work with the non-tilt version of sprockets.